### PR TITLE
Make input of svgToPdf polymorphic

### DIFF
--- a/src/SvgToPdf.hs
+++ b/src/SvgToPdf.hs
@@ -1,19 +1,31 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 module SvgToPdf where
 
 import Graphics.Rendering.Cairo.LibRSvg
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import Graphics.Rendering.Cairo (withPDFSurface, renderWith)
 
-loadSvg :: FilePath -> IO Svg
-loadSvg path = do
-  result <- fromBuffer =<< BS.readFile path
+class CanContainInput a where
+  readInput :: a -> IO ByteString
+
+instance CanContainInput FilePath where
+  readInput = BS.readFile
+
+instance CanContainInput ByteString where
+  readInput = return
+
+loadSvg :: CanContainInput a => a -> IO Svg
+loadSvg inp = do
+  result <- fromBuffer =<< readInput inp
   case result of
     Left bs -> fail $ BSC.unpack bs
     Right sp -> pure sp
 
-svgToPdf :: FilePath -> FilePath -> IO ()
+svgToPdf :: CanContainInput a => a -> FilePath -> IO ()
 svgToPdf inp out = do
   svgPtr <- loadSvg inp
   (sizeX, sizeY) <- dimensions svgPtr


### PR DESCRIPTION
Reason -- compatibility with servant-multipart types, but this may be useful generally.